### PR TITLE
Handle case where user sends GC as gift via PPDG

### DIFF
--- a/skip.js
+++ b/skip.js
@@ -1,3 +1,6 @@
+// Create an observer instance linked to the callback function
+let observer = null;
+
 function skip(button, inner_text) {
     let buttons = document.querySelectorAll(button);
 
@@ -5,14 +8,62 @@ function skip(button, inner_text) {
     for(let i = 0;i < buttons.length; ++i) {
         if(buttons[i].innerText === inner_text)
             buttons[i].click();
+            if (observer != null) {
+                observer.disconnect(); // with mission accomplished, deactivate observer
+                observer = null;
+            }
     }
 }
 
-switch (window.location.hostname) {
+function go() {
+    switch (window.location.hostname) {
     case 'delivery.cardago.com':
         skip('.btn_base', 'READY TO OPEN YOUR GIFT CARD?');
         break;
     case 'www.paypal.com':
         skip('[data-pa-click]', 'Skip');
         break;
+    }
 }
+
+function configure_dom_observer(id_to_observe) {
+    // Select the node that will be observed for mutations
+    let targetNode = document.getElementById(id_to_observe);
+
+    // Options for the observer (which mutations to observe)
+    const config = { attributes: true, childList: true, subtree: true };
+
+    // Callback function to execute when mutations are observed
+    const callback = function(mutationsList, observer) {
+        // Use traditional 'for loops' for IE 11
+        for(let mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                //console.log('A child node has been added or removed.');
+                go();
+            }
+            else if (mutation.type === 'attributes') {
+                //console.log('The ' + mutation.attributeName + ' attribute was modified.');
+                // don't care about attribute mutations for now
+            }
+        }
+    };
+
+    observer = new MutationObserver(callback);
+    // Start observing the target node for configured mutations
+    observer.observe(targetNode, config);
+}
+
+function init() {
+    switch (window.location.hostname) {
+        case 'delivery.cardago.com':
+            configure_dom_observer('content-main');
+            break;
+        case 'www.paypal.com':
+            configure_dom_observer('root');
+            break;
+    }
+
+    go();
+}
+
+init();

--- a/skip.js
+++ b/skip.js
@@ -7,11 +7,11 @@ function skip(button, inner_text) {
     // Confirm we aren't about to click on something we don't intend to.
     for(let i = 0;i < buttons.length; ++i) {
         if(buttons[i].innerText === inner_text)
-            buttons[i].click();
             if (observer != null) {
                 observer.disconnect(); // with mission accomplished, deactivate observer
                 observer = null;
             }
+            buttons[i].click();
     }
 }
 

--- a/skip.js
+++ b/skip.js
@@ -6,12 +6,13 @@ function skip(button, inner_text) {
 
     // Confirm we aren't about to click on something we don't intend to.
     for(let i = 0;i < buttons.length; ++i) {
-        if(buttons[i].innerText === inner_text)
+        if (buttons[i].innerText === inner_text) {
             if (observer != null) {
                 observer.disconnect(); // with mission accomplished, deactivate observer
                 observer = null;
             }
             buttons[i].click();
+        }
     }
 }
 

--- a/skip.js
+++ b/skip.js
@@ -1,70 +1,61 @@
-// Create an observer instance linked to the callback function
-let observer = null;
+function skip(button, inner_text, observer) {
+  let buttons = document.querySelectorAll(button);
 
-function skip(button, inner_text) {
-    let buttons = document.querySelectorAll(button);
+  // Confirm we aren't about to click on something we don't intend to.
+  for(let i = 0;i < buttons.length; ++i) {
+    if (buttons[i].innerText === inner_text) {
+      if (observer !== undefined) {
+        observer.disconnect(); // with mission accomplished, deactivate observer
+      }
 
-    // Confirm we aren't about to click on something we don't intend to.
-    for(let i = 0;i < buttons.length; ++i) {
-        if (buttons[i].innerText === inner_text) {
-            if (observer != null) {
-                observer.disconnect(); // with mission accomplished, deactivate observer
-                observer = null;
-            }
-            buttons[i].click();
-        }
+      buttons[i].click();
     }
+  }
 }
 
-function go() {
-    switch (window.location.hostname) {
-    case 'delivery.cardago.com':
-        skip('.btn_base', 'READY TO OPEN YOUR GIFT CARD?');
-        break;
-    case 'www.paypal.com':
-        skip('[data-pa-click]', 'Skip');
-        break;
-    }
+function go(observer) {
+  switch (window.location.hostname) {
+  case 'delivery.cardago.com':
+    skip('.btn_base', 'READY TO OPEN YOUR GIFT CARD?', observer);
+    break;
+  case 'www.paypal.com':
+    skip('[data-pa-click]', 'Skip', observer);
+    break;
+  }
 }
 
 function configure_dom_observer(id_to_observe) {
-    // Select the node that will be observed for mutations
-    let targetNode = document.getElementById(id_to_observe);
+  // Select the node that will be observed for mutations
+  let targetNode = document.getElementById(id_to_observe);
 
-    // Options for the observer (which mutations to observe)
-    const config = { attributes: true, childList: true, subtree: true };
+  // Options for the observer (which mutations to observe)
+  const config = { childList: true, subtree: true };
 
-    // Callback function to execute when mutations are observed
-    const callback = function(mutationsList, observer) {
-        // Use traditional 'for loops' for IE 11
-        for(let mutation of mutationsList) {
-            if (mutation.type === 'childList') {
-                //console.log('A child node has been added or removed.');
-                go();
-            }
-            else if (mutation.type === 'attributes') {
-                //console.log('The ' + mutation.attributeName + ' attribute was modified.');
-                // don't care about attribute mutations for now
-            }
-        }
-    };
+  // Callback function to execute when mutations are observed
+  const callback = function(mutationsList, obs) {
+    for(let mutation of mutationsList) {
+      if (mutation.type === 'childList') {
+        go(obs);
+      }
+    }
+  };
 
-    observer = new MutationObserver(callback);
-    // Start observing the target node for configured mutations
-    observer.observe(targetNode, config);
+  let observer = new MutationObserver(callback);
+  // Start observing the target node for configured mutations
+  observer.observe(targetNode, config);
 }
 
 function init() {
-    switch (window.location.hostname) {
-        case 'delivery.cardago.com':
-            configure_dom_observer('content-main');
-            break;
-        case 'www.paypal.com':
-            configure_dom_observer('root');
-            break;
-    }
+  switch (window.location.hostname) {
+    case 'delivery.cardago.com':
+      configure_dom_observer('content-main');
+      break;
+    case 'www.paypal.com':
+      configure_dom_observer('root');
+      break;
+  }
 
-    go();
+  go();
 }
 
 init();


### PR DESCRIPTION
When a user sends a gift card as a gift instead of buying for one's self, PPDG renders some additional content before rendering the skip button. As such, in its current state, the code is evaluated before there's a skip button to click. This amendment attaches a DOM observer and will attempt the skip button logic for each time a dom element is added or removed. Attribute changes are ignored. An initial attempt at clicking the skip button is still made for pages where this is not an issue.